### PR TITLE
Fix missing ShipSkin item subtype

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "pssapi"
 description = "Wrapper for the Pixel Starships API"
-version = "0.2.1"
+version = "0.2.2"
 license = "MIT"
 authors = [
     "The worst. <theworstpss@gmail.com>",

--- a/src/pssapi/__init__.py
+++ b/src/pssapi/__init__.py
@@ -9,4 +9,4 @@ __all__ = [
     "PssApiClient",
 ]
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/src/pssapi/entities/metadata/entity_metadata_base.py
+++ b/src/pssapi/entities/metadata/entity_metadata_base.py
@@ -3,4 +3,9 @@ import json as _json
 
 class EntityMetadata(object):
     def __init__(self, metadata: str):
-        self._metadata_dict: dict = _json.loads((metadata.strip() if metadata else "") or "{}")
+        try:
+            json_loads = _json.loads((metadata.strip() if metadata else "") or "{}")
+        except _json.JSONDecodeError:
+            json_loads = {}
+
+        self._metadata_dict: dict = json_loads

--- a/src/pssapi/enums/item_sub_type.py
+++ b/src/pssapi/enums/item_sub_type.py
@@ -42,6 +42,7 @@ class ItemSubType(_StrEnumBase):
     REVIVE = "Revive"
     ROOM_SKIN = "RoomSkin"
     SCRATCHY = "Scratchy"
+    SHIP_SKIN = "ShipSkin"
     SITUATION = "Situation"
     SKIN = "Skin"
     SPEED_UP_CONSTRUCTION = "SpeedUpConstruction"


### PR DESCRIPTION
I added the missing enum for ShipSkin in item_sub_type and I also needed to harden the ItemDesign `Metadata` JSON decoding because Savy don't always use JSON, but for example `Metadata="skin:63" `